### PR TITLE
Fix: Disallow selecting of letters on keyboard

### DIFF
--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -48,7 +48,7 @@ const Keyboard = ({ letterStatuses, addLetter, onEnterPress, onDeletePress, game
   }, [handleKeyDown])
 
   return (
-    <div className="w-full flex flex-col items-center mb-3">
+    <div className="w-full flex flex-col items-center mb-3 select-none">
       {keyboardLetters.map((row, idx) => (
         <div key={idx} className="w-full flex justify-center my-[5px]">
           {idx === 2 && (


### PR DESCRIPTION
- Fix for Issue #17 
- Added [select-none](https://tailwindcss.com/docs/user-select#disabling-text-selection) tailwind class to parent div of keyboard
- can verify the fix at [kancherlakishorereddy.github.io/word-master](https://kancherlakishorereddy.github.io/word-master)