### PR TITLE
Avoids marking repeated letters in the guess as yellow when that letter appears only once in the answer word

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -164,34 +164,29 @@ function App() {
 
   const updateCellStatuses = (word, rowNumber) => {
     setCellStatuses((prev) => {
-      let ans = answer
-      let wor = word
       const newCellStatuses = [...prev]
       newCellStatuses[rowNumber] = [...prev[rowNumber]]
-      const wordLength = wor.length
+      const wordLength = word.length
+      const answerLetters = answer.split("");
+
+      // set all to gray
+      for (let i = 0; i < wordLength; i++) {
+        newCellStatuses[rowNumber][i] = status.gray
+      }
 
       // check greens
-      for (let i = 0; i < wordLength; i++) {
-        if (wor[i] === ans[i]) {
+      for (let i = wordLength - 1; i >= 0; i--) {
+        if (word[i] === answer[i]) {
           newCellStatuses[rowNumber][i] = status.green
-          ans = ans.substr(0, i) + '.' + ans.substr(i + 1)
-          wor = wor.substr(0, i) + '.' + wor.substr(i + 1)
+          answerLetters.splice(i, 1)
         }
       }
 
       // check yellows
       for (let i = 0; i < wordLength; i++) {
-        if (wor[i] === '.') continue
-
-        if (ans.includes(wor[i])) {
+        if (answerLetters.includes(word[i]) && newCellStatuses[rowNumber][i] !== status.green) {
           newCellStatuses[rowNumber][i] = status.yellow
-        }
-      }
-
-      // set rest to gray
-      for (let i = 0; i < wordLength; i++) {
-        if (newCellStatuses[rowNumber][i] === status.unguessed) {
-          newCellStatuses[rowNumber][i] = status.gray
+          answerLetters.splice(answerLetters.indexOf(word[i]), 1)
         }
       }
 


### PR DESCRIPTION
Fixes #16 Repeated letters being marked all yellow when that letter occurs only once in the correct answer word.

- Makes a list of the letters in the answer, and removes each letter from that list when it is matched with a letter from the guessed word, to avoid matching a single answer letter with multiple guessed letters.
- Sets letters to grey first as this is the default.
- Iterates backwards through the green letters (exact matches) to allow matches to be removed from the answer letters list by index.
- Removes the previous logic of crossing out letters with dots when exactly matched to prevent a later inexact match, as this is now covered by keeping the list of answer letters.

Note - I've tested this a fair bit manually, but it's hard to be 100% confident it's good(!)