### PR TITLE
Fixes #8 - Prevents the enter key from re-activating the last-clicked UI element

### DIFF
--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -34,6 +34,7 @@ const Keyboard = ({ letterStatuses, addLetter, onEnterPress, onDeletePress, game
         addLetter(letter)
       } else if (letter === 'ENTER') {
         onEnterPress()
+        event.preventDefault()
       } else if (letter === 'BACKSPACE') {
         onDeletePress()
       }


### PR DESCRIPTION
Fixes issue #8 - use event.preventDefault() after processing an enter pressed event, to avoid the enter key (re)activating the currently focused UI element.  (Note, it remains possible to activate the focused element by pressing the space key, if needed).