### PR TITLE
Fix clicking out of game over modal to unplayable state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -285,6 +285,8 @@ function App() {
       <Modal
         isOpen={modalIsOpen}
         onRequestClose={closeModal}
+        shouldCloseOnEsc={false}
+        shouldCloseOnOverlayClick={false}
         style={customStyles}
         contentLabel="Game End Modal"
       >


### PR DESCRIPTION
Really simple fix to prevent the user from putting the game in an unplayable state by clicking out of the game end modal