### PR TITLE
toggle endgame UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -235,6 +235,18 @@ function App() {
     })
   }
 
+  const playAgain = () => {
+    setAnswer(initialStates.answer)
+    setGameState(initialStates.gameState)
+    setBoard(initialStates.board)
+    setCellStatuses(initialStates.cellStatuses)
+    setCurrentRow(initialStates.currentRow)
+    setCurrentCol(initialStates.currentCol)
+    setLetterStatuses(initialStates.letterStatuses)
+    closeModal()
+    streakUpdated.current = false
+  }
+
   const modalStyles = {
     overlay: {
       position: 'fixed',
@@ -322,17 +334,7 @@ function App() {
           currentStreak={currentStreak}
           longestStreak={longestStreak}
           answer={answer}
-          playAgain={() => {
-            setAnswer(initialStates.answer)
-            setGameState(initialStates.gameState)
-            setBoard(initialStates.board)
-            setCellStatuses(initialStates.cellStatuses)
-            setCurrentRow(initialStates.currentRow)
-            setCurrentCol(initialStates.currentCol)
-            setLetterStatuses(initialStates.letterStatuses)
-            closeModal()
-            streakUpdated.current = false
-          }}
+          playAgain={playAgain}
         />
         <SettingsModal
           isOpen={settingsModalIsOpen}

--- a/src/App.js
+++ b/src/App.js
@@ -292,7 +292,7 @@ function App() {
           <h1 className="flex-1 text-center text-xl xxs:text-2xl sm:text-4xl tracking-wide font-bold font-righteous">
             WORD MASTER
           </h1>
-          <div className={darkMode ? 'dark' : ''}>
+          <div className={gameState === state.playing ? 'hidden' : (darkMode ? 'dark' : '')}>
             <button
               type="button"
               className="rounded-lg px-6 py-2 text-lg nm-flat-background dark:nm-flat-background-dark hover:nm-inset-background dark:hover:nm-inset-background-dark text-primary dark:text-primary-dark"

--- a/src/App.js
+++ b/src/App.js
@@ -292,6 +292,15 @@ function App() {
           <h1 className="flex-1 text-center text-xl xxs:text-2xl sm:text-4xl tracking-wide font-bold font-righteous">
             WORD MASTER
           </h1>
+          <div className={darkMode ? 'dark' : ''}>
+            <button
+              type="button"
+              className="rounded-lg px-6 py-2 text-lg nm-flat-background dark:nm-flat-background-dark hover:nm-inset-background dark:hover:nm-inset-background-dark text-primary dark:text-primary-dark"
+              onClick={playAgain}
+            >
+              Play Again
+            </button>
+          </div>
           <button
             type="button"
             onClick={() => setInfoModalIsOpen(true)}

--- a/src/components/EndGameModal.js
+++ b/src/components/EndGameModal.js
@@ -1,3 +1,4 @@
+import { ReactComponent as Close } from '../data/Close.svg'
 import Modal from 'react-modal'
 import Success from '../data/Success.png'
 import Fail from '../data/Cross.png'
@@ -38,6 +39,12 @@ export const EndGameModal = ({
     >
       <div className={darkMode ? 'dark' : ''}>
         <div className="h-full flex flex-col items-center justify-center max-w-[300px] mx-auto text-primary dark:text-primary-dark">
+            <button
+              className="absolute top-4 right-4 rounded-full nm-flat-background dark:nm-flat-background-dark text-primary dark:text-primary-dark p-1 w-6 h-6 sm:p-2 sm:h-8 sm:w-8 hover:nm-inset-background dark:hover:nm-inset-background-dark"
+              onClick={handleClose}
+            >
+              <Close />
+            </button>
           {gameState === state.won && (
             <>
               <img src={Success} alt="success" height="auto" width="auto" />

--- a/src/index.css
+++ b/src/index.css
@@ -37,3 +37,7 @@ html {
 .font-righteous {
   font-family: 'Righteous', cursive;
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
proposed fix for issue #41 / #43, toggle words/endgame

- hamburger button to (re)open endgame
- close button to view words

![wm43-1hamburger](https://user-images.githubusercontent.com/592062/148844322-c93ab9e3-afc6-45fa-b7dc-460dbb3e381e.png)

![wm43-2close](https://user-images.githubusercontent.com/592062/148844342-cdc78917-263d-4927-88f5-7384bedae131.png)


![wm43-3init](https://user-images.githubusercontent.com/592062/148844355-7a4ef52a-e6ed-4da3-923f-7ce3882a6108.png)
