### PR TITLE
Remove "lense"

### DIFF
--- a/src/data/answers.js
+++ b/src/data/answers.js
@@ -1072,7 +1072,6 @@ const answers = [
   'lemon',
   'lemur',
   'lends',
-  'lense',
   'level',
   'lever',
   'licks',


### PR DESCRIPTION
Pretty sure "lense" is not a word. I couldn't find any online dictionary that says that it is.

And if you're wondering if this PR is because I'm salty over losing a round of this _incredible_ game... you'd be right 😉