### PR TITLE
Improve sizing on medium-sized screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -349,7 +349,7 @@ function App() {
           >
             <Settings />
           </button>
-          <h1 className="flex-1 text-center text-xl xxs:text-2xl sm:text-4xl tracking-wide font-bold font-righteous">
+          <h1 className="flex-1 text-center text-xl xxs:text-2xl sm:text-3xl tracking-wide font-bold font-righteous">
             WORD MASTER
           </h1>
           <button
@@ -371,7 +371,7 @@ function App() {
                       rowNumber,
                       colNumber,
                       letter
-                    )} inline-flex items-center font-medium justify-center text-lg w-[13vw] h-[13vw] xs:w-14 xs:h-14 sm:w-20 sm:h-20 rounded-full`}
+                    )} inline-flex items-center font-medium justify-center text-lg w-[13vw] h-[13vw] xs:w-14 xs:h-14 rounded-full`}
                   >
                     {letter}
                   </span>


### PR DESCRIPTION
The display is a bit wonky on my 13" laptop screen. This reduces the size of the board and logo so everything fits

### Before

<img width="1432" alt="Firefox 2022-01-27 at 23 25 56" src="https://user-images.githubusercontent.com/2379650/151487109-2b7343bf-bc17-4994-95ca-01f2058cfacd.png">


### After



<img width="1411" alt="Firefox 2022-01-27 at 23 26 15" src="https://user-images.githubusercontent.com/2379650/151487129-4a7e0fde-b406-4793-bfc1-cea1642f655d.png">


