### PR TITLE
Auto-set darkMode to OS / User Agent setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ type State = {
   currentCol: number
   letterStatuses: () => { [key: string]: string }
   submittedInvalidWord: boolean
+  darkMode: boolean
 }
 
 function App() {
@@ -62,6 +63,7 @@ function App() {
       return letterStatuses
     },
     submittedInvalidWord: false,
+    darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
   }
 
   const [answer, setAnswer] = useLocalStorage('stateAnswer', initialStates.answer())
@@ -112,7 +114,7 @@ function App() {
     setInfoModalIsOpen(false)
   }
 
-  const [darkMode, setDarkMode] = useLocalStorage('dark-mode', false)
+  const [darkMode, setDarkMode] = useLocalStorage('dark-mode', initialStates.darkMode)
   const toggleDarkMode = () => setDarkMode((prev: boolean) => !prev)
 
   useEffect(() => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,12 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+
+// Stub window.matchMedia as needed
+window.matchMedia = window.matchMedia || function () {
+  return {
+    matches: false,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  };
+};


### PR DESCRIPTION
- Add `darkMode` to `initialStates` (and `State` type)
- Initialize `darkMode` via `prefers-color-scheme`
  - This will not override the user's existing `dark-mode` setting