### PR TITLE
Fix background color on vertical overflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
       src="https://plausible.io/js/plausible.js"
     ></script>
   </head>
-  <body>
+  <body class="bg-background dark:bg-background-dark">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,11 @@ function App() {
   const [darkMode, setDarkMode] = useLocalStorage('dark-mode', false)
   const toggleDarkMode = () => setDarkMode((prev: boolean) => !prev)
 
+  useEffect(
+    () => document.documentElement.classList[darkMode ? 'add' : 'remove']('dark'),
+    [darkMode]
+  )
+
   useEffect(() => {
     if (gameState !== state.playing) {
       setTimeout(() => {
@@ -339,7 +344,7 @@ function App() {
   }
 
   return (
-    <div className={darkMode ? 'dark' : ''}>
+    <div>
       <div className={`flex flex-col justify-between h-fill bg-background dark:bg-background-dark`}>
         <header className="flex items-center py-2 px-3 text-primary dark:text-primary-dark">
           <button

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,6 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   box-sizing: border-box;
-  /* background-color: hsl(231, 16%, 92%); */
 }
 
 code {


### PR DESCRIPTION
resolves #115 

## Changes

- using a useEffect, toggles application of the `dark` className on the html element whenever darkMode state is updated, (be it onload, or state change)
- added conditional tailwind classes to the body element `bg-background dark:bg-background-dark`
- removed deprecated `background-color` key in the index css

## Notes
- This methodology for accessing the `html` tag [is widely supported](https://developer.mozilla.org/en-US/docs/Web/API/document/documentElement)

## Sample
![Screen Shot 2022-02-08 at 3 56 50 AM](https://user-images.githubusercontent.com/8313765/152952247-46780197-b40e-43c3-9a4b-eef61e88a581.png)

